### PR TITLE
Include and build PROJ as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PROJ"]
+	path = PROJ
+	url = https://github.com/OSGeo/PROJ.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,24 @@
 [package]
 name = "proj-sys"
 description = "Rust bindings for PROJ v7.0.x"
-repository = "https://github.com/urschrei/proj-sys"
+repository = "https://github.com/georust/proj-sys"
 version = "0.13.0"
 readme = "README.md"
 authors = ["Stephan Hügel <urschrei@gmail.com>"]
 keywords = ["proj", "projection", "osgeo", "geo", "geospatial"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+links = "proj"
 
 [dependencies]
 
 [build-dependencies]
 bindgen = "0.52.0"
+cmake = "0.1"
 
 [features]
 nobuild = []
+bundled_proj = []
 
 [package.metadata.docs.rs]
 features = [ "nobuild" ] # This feature will be enabled during the docs.rs build

--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@
 
 A guide to the functions can be found here: https://proj.org/development/reference/functions.html. Run `cargo doc (optionally --open)` to generate the crate documentation.
 
-# Requirements
-This crate tracks the **latest stable release** of `PROJ`.  
-PROJ `v7.0.x` must be present on your system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither tested or supported.
+## Requirements
+
+Sqlite3 must be present on your system.
+
+By default, this crate depends on a pre-built library, so PROJ `v7.0.x` must be present on your system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither tested or supported.
+
+## Using the Bundled PROJ
+
+This crate can internally build and depend on a bundled PROJ `v7.0.0` library, which can be enabled via the "bundled_proj" feature. This might make it easier to compile the crate, but it is not thoroughly tested yet so it might not work on some platforms.
+
+Currently this feature only supports Linux.
 
 ## License
 
@@ -17,4 +25,3 @@ Licensed under either of
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
-


### PR DESCRIPTION
# Summary

- change is added behind the `bundled_proj` Cargo feature
- add PROJ as a submodule and build it automatically
- inspired by https://github.com/georust/proj-sys/issues/3

# Known Issues

- PROJ depends on Sqlite3, which still needs to be installed manually to make the build succeed