### PR TITLE
Use pkg-config to configure additional search paths on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rust:
   - nightly
 before_install:
   - sudo apt-get update
-  - wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
+  - wget https://github.com/OSGeo/PROJ/releases/download/7.0.0/proj-7.0.0.tar.gz
   - tar -xzvf proj-7.0.0.tar.gz
   - pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 0.13.0
+- Add bundled Linux build option
+
 # 0.12.0
 - Update to PROJ 7.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proj-sys"
 description = "Rust bindings for PROJ v7.0.x"
 repository = "https://github.com/georust/proj-sys"
-version = "0.13.0"
+version = "0.15.0"
 readme = "README.md"
 authors = ["Stephan Hügel <urschrei@gmail.com>"]
 keywords = ["proj", "projection", "osgeo", "geo", "geospatial"]
@@ -14,6 +14,7 @@ links = "proj"
 
 [build-dependencies]
 bindgen = "0.52.0"
+pkg-config = "0.3.17"
 cmake = "0.1"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ By default, this crate depends on a pre-built library, so PROJ `v7.0.x` must be 
 
 ## Using the Bundled PROJ
 
-This crate can internally build and depend on a bundled PROJ `v7.0.0` library, which can be enabled via the "bundled_proj" feature. This might make it easier to compile the crate, but it is not thoroughly tested yet so it might not work on some platforms.
-
-Currently this feature only supports Linux.
+This crate can internally build and depend on a bundled PROJ `v7.0.0` library, by enabling the `bundled_proj` feature. This may make it easier to compile the crate, but is not yet thoroughly tested, and **currently only supports Linux**.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,55 @@
 use bindgen;
+#[cfg(all(target_os="macos", not(feature = "bundled_proj"), not(feature = "nobuild")))]
+use pkg_config;
+#[cfg(all(not(target_os="macos"), feature = "bundled_proj", not(feature = "nobuild")))]
 use cmake;
 use std::env;
 use std::path::PathBuf;
 
+const MINIMUM_PROJ_VERSION: &str = "7.0.0";
+
 #[cfg(feature = "nobuild")]
 fn main() {} // Skip the build script on docs.rs
 
-#[cfg(all(not(feature = "nobuild"), not(feature = "bundled_proj")))]
+
+// on macOS, we sometimes need additional search paths, which we get using pkg-config
+#[cfg(all(target_os="macos", not(feature = "nobuild"), not(feature = "bundled_proj")))]
 fn main() {
+    let pk = pkg_config::Config::new()
+        .atleast_version(MINIMUM_PROJ_VERSION)
+        .probe("proj")
+        .unwrap();
     // Tell cargo to tell rustc to link the system proj
     // shared library.
+    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
+    println!("cargo:rustc-link-lib=proj");
+    let include_path = pk.include_paths[0].to_string_lossy();
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        .clang_arg(format!("-I{}", include_path))
+        .trust_clang_mangling(false)
+        .blacklist_type("max_align_t")
+        // The input header we would like to generate
+        // bindings for.
+        .header("wrapper.h")
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
+// non-macOS, not using bundled PROJ
+#[cfg(all(not(target_os="macos"), not(feature = "nobuild"), not(feature = "bundled_proj")))]
+fn main() {
     println!("cargo:rustc-link-lib=proj");
 
     // The bindgen::Builder is the main entry point
@@ -37,7 +77,10 @@ fn main() {
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     if &target_os != "linux" {
-        panic!("Currently the bundled_proj feature only supports Linux. Your target platform: {}", target_os);
+        panic!(
+            "Currently the bundled_proj feature only supports Linux. Your target platform: {}",
+            target_os
+        );
     }
 
     // Build PROJ from the included submodule.
@@ -46,7 +89,10 @@ fn main() {
     let proj = config.build();
 
     // Tell cargo to tell rustc where to look for PROJ.
-    println!("cargo:rustc-link-search=native={}", proj.join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        proj.join("lib").display()
+    );
     // Tell cargo to tell rustc to link PROJ.
     println!("cargo:rustc-link-lib=dylib=proj");
 


### PR DESCRIPTION
Closes #7 