### PR TITLE
Enable pkg-config on Linux, make it optional on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+dist: xenial
+
 rust:
   - stable
   - beta
@@ -8,21 +10,20 @@ rust:
 os:
   - linux
   - osx
-
+# by default, test vanilla setup on all three channels
 env:
   global:
     - PROJ_FEATURES=""
 
+# test both features on Linux stable, but only pkg_config on macOS stable
 jobs:
   include:
     - os: linux
-      dist: xenial
-      env:
-        - PROJ_FEATURES="--features bundled_proj"
-        - PROJ_FEATURES="--features pkg_config"
+      env: PROJ_FEATURES="--features bundled_proj"
+    - os: linux
+      env: PROJ_FEATURES="--features pkg_config"
     - os: osx
-      env:
-        - PROJ_FEATURES="--features pkg-config"
+      env: PROJ_FEATURES="--features pkg_config"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
       sudo apt-get -y install pkg-config
       wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
       tar -xzvf proj-7.0.0.tar.gz
-      sed -i 's/includedir/fields\ndatarootdir=${prefix}/share/' proj-7.0.0/proj.pc.in
+      sed -i "" "s|includedir=|includedir=@includedir@\ndatarootdir=${prefix}/share/|" proj-7.0.0/proj.pc.in
       pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
       sudo apt-get -y install pkg-config
       wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
       tar -xzvf proj-7.0.0.tar.gz
+      sed -i 's/includedir/fields\ndatarootdir=${prefix}/share/' proj-7.0.0/proj.pc.in
       pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,16 @@ jobs:
       dist: xenial
       env:
         - PROJ_FEATURES="--features bundled_proj"
+        - PROJ_FEATURES="--features pkg-config"
+    - os: osx
+      env:
+        - PROJ_FEATURES="--features pkg-config"
 
 before_install:
-  - echo $TRAVIS_OS_NAME
-  - echo $PROJ_FEATURES
   - |
-    if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PROJ_FEATURES" = "" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PROJ_FEATURES" != "bundled_proj" ]; then
       sudo apt-get update
+      sudo apt-get -y install pkg-config
       wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
       tar -xzvf proj-7.0.0.tar.gz
       pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd
@@ -33,7 +36,7 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update
-      brew install pkg-config
+      brew upgrade pkg-config
       brew upgrade proj
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
       sudo apt-get -y install pkg-config
       wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
       tar -xzvf proj-7.0.0.tar.gz
-      sed -i "" "s|includedir=|includedir=@includedir@\ndatarootdir=${prefix}/share/|" proj-7.0.0/proj.pc.in
+      sed -i "s|includedir=|includedir=@includedir@\ndatarootdir=${prefix}/share/|" proj-7.0.0/proj.pc.in
       pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       dist: xenial
       env:
         - PROJ_FEATURES="--features bundled_proj"
-        - PROJ_FEATURES="--features pkg-config"
+        - PROJ_FEATURES="--features pkg_config"
     - os: osx
       env:
         - PROJ_FEATURES="--features pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proj-sys"
 description = "Rust bindings for PROJ v7.0.x"
 repository = "https://github.com/georust/proj-sys"
-version = "0.15.0"
+version = "0.16.0"
 readme = "README.md"
 authors = ["Stephan Hügel <urschrei@gmail.com>"]
 keywords = ["proj", "projection", "osgeo", "geo", "geospatial"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cmake = "0.1"
 
 [features]
 nobuild = []
-pkg-config = []
+pkg_config = []
 bundled_proj = []
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ cmake = "0.1"
 
 [features]
 nobuild = []
+pkg-config = []
 bundled_proj = []
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,18 @@ A guide to the functions can be found here: https://proj.org/development/referen
 
 By default, this crate depends on a pre-built library, so PROJ `v7.0.x` must be present on your system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither tested or supported.
 
-### Linux: Using the Bundled PROJ library
+## Optional Features
+Enable these in your `Cargo.toml` like so:
 
-This crate can internally build and depend on a bundled PROJ `v7.0.0` library, by enabling the `bundled_proj` feature. This may make it easier to compile the crate, but is not yet thoroughly tested, and **currently only supports Linux**. Note that SQLite3 must be present on your system if you wish to use this feature.
+`proj-sys = { version = "0.16", features = ["pkg_config"] }`  
+`proj-sys = { version = "0.16", features = ["bundled_proj"] }`  
 
-### macOS
+Note that these features are **mutually exclusive**.
 
-The macOS build script uses `pkgconfig` to add search paths, so you must have it installed (it's available on Homebrew and Macports)
+1. `pkg_config` (Linux and macOS targets)
+    - uses [`pkgconfig`](https://en.wikipedia.org/wiki/Pkg-config) to add search paths to the build script, so you must have it installed (it's available on Homebrew, Macports, apt etc.)
+2. `bundled_proj` (Linux targets **only**):
+    - This crate can internally build and depend on a bundled PROJ library, by enabling the `bundled_proj` feature. This may make it easier to compile the crate, but is not yet thoroughly tested. Note that SQLite3 must be present on your system if you wish to use this feature.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
 use bindgen;
 #[cfg(all(
     not(target_os = "macos"),
+    not(feature = "pkg_config"),
     feature = "bundled_proj",
     not(feature = "nobuild")
 ))]
 use cmake;
 #[cfg(all(
-    target_os = "macos",
+    feature = "pkg_config",
     not(feature = "bundled_proj"),
     not(feature = "nobuild")
 ))]
@@ -14,6 +15,11 @@ use pkg_config;
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(all(
+    feature = "pkg_config",
+    not(feature = "bundled_proj"),
+    not(feature = "nobuild")
+))]
 const MINIMUM_PROJ_VERSION: &str = "7.0.0";
 
 #[cfg(feature = "nobuild")]
@@ -21,7 +27,7 @@ fn main() {} // Skip the build script on docs.rs
 
 // We sometimes need additional search paths, which we get using pkg-config
 #[cfg(all(
-    feature = "pkg-config",
+    feature = "pkg_config",
     not(feature = "nobuild"),
     not(feature = "bundled_proj")
 ))]
@@ -60,7 +66,7 @@ fn main() {
 
 // Vanilla
 #[cfg(all(
-    not(feature = "pkg-config"),
+    not(feature = "pkg_config"),
     not(feature = "nobuild"),
     not(feature = "bundled_proj")
 ))]

--- a/build.rs
+++ b/build.rs
@@ -19,9 +19,9 @@ const MINIMUM_PROJ_VERSION: &str = "7.0.0";
 #[cfg(feature = "nobuild")]
 fn main() {} // Skip the build script on docs.rs
 
-// on macOS, we sometimes need additional search paths, which we get using pkg-config
+// We sometimes need additional search paths, which we get using pkg-config
 #[cfg(all(
-    target_os = "macos",
+    feature = "pkg-config",
     not(feature = "nobuild"),
     not(feature = "bundled_proj")
 ))]
@@ -58,9 +58,9 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
-// non-macOS, not using bundled PROJ
+// Vanilla
 #[cfg(all(
-    not(target_os = "macos"),
+    not(feature = "pkg-config"),
     not(feature = "nobuild"),
     not(feature = "bundled_proj")
 ))]
@@ -88,7 +88,11 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
-#[cfg(all(not(feature = "nobuild"), feature = "bundled_proj"))]
+#[cfg(all(
+    not(feature = "pkg-config"),
+    not(feature = "nobuild"),
+    feature = "bundled_proj"
+))]
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     if &target_os != "linux" {


### PR DESCRIPTION
This feature can't merge until a new PROJ version is released, since v7.0.0 has a broken `datarootdir` config.